### PR TITLE
feat: --no-watch flag, add watch: true to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Options
   --host              Sets the host the server should listen from
   --http2             Instructs the server to enable HTTP2
   --live-reload       Instructs the client to perform a full page reload after each build
+  --no-watch          Does not apply \`watch: true\` to the config, allowing for greater customization
   --open              Opens the default browser to the set host and port
   --port              Sets the port on which the server should listen
   --progress          Shows build progress in the client
@@ -90,6 +91,10 @@ Examples
 ## Flags
 
 Please reference the [`webpack-plugin-serve` Options](https://github.com/shellscape/webpack-plugin-serve#options) for information and use. Most options are analogous to the flags listed above.
+
+#### `--no-watch`
+
+By default, the CLI will apply `watch: true` to the first config in the targeted webpack config file. To customize watching or `watchOptions`, please use this flag and customize the config(s) accordingly.
 
 ## package.json Options
 

--- a/bin/webpack-serve
+++ b/bin/webpack-serve
@@ -35,8 +35,8 @@ const help = chalk`
     --all               Apply webpack-plugin-serve to all compilers in the config
     --client.address    Overrides the WebSocket address in the client
     --client.retry      Instructs the client to attempt to reconnect all WebSockets when interrupted
-    --client.silent     Instructs the client not to log anything to the console.
-    --compress          Enables compression middleware which serves files with GZip compression.
+    --client.silent     Instructs the client not to log anything to the console
+    --compress          Enables compression middleware which serves files with GZip compression
     --config            A path to a webpack config file
     --config.\{name\}   A path to a webpack config file, and the config name to run
     --help              Displays this message
@@ -45,6 +45,7 @@ const help = chalk`
     --host              Sets the host the server should listen from
     --http2             Instructs the server to enable HTTP2
     --live-reload       Instructs the client to perform a full page reload after each build
+    --no-watch          Does not apply \`watch: true\` to the config, allowing for greater customization
     --open              Opens the default browser to the set host and port
     --port              Sets the port on which the server should listen
     --progress          Shows build progress in the client
@@ -52,7 +53,7 @@ const help = chalk`
     --static            Sets the directory from which static files will be served
     --status            Shows build status (errors, warnings) in the client
     --version           Displays webpack-nano and webpack versions
-    --wait-for-build    Instructs the server to halt middleware processing until the current build is done.
+    --wait-for-build    Instructs the server to halt middleware processing until the current build is done
 
   {underline Examples}
     $ webpack-serve
@@ -96,6 +97,7 @@ webpack       v${webpack.version}
   }
 
   const config = await loadConfig(argv);
+
   run(config, log);
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -95,11 +95,11 @@ const loadConfig = async (argv) => {
 
     const configType = typeof configExport;
     let config = await configTypes[configType](configExport, argv);
-    const watchConfig = [].concat(config).find((c) => !!c.watch);
-
     config = await apply(config, argv, resolvedPath);
 
+    const watchConfig = [].concat(config).find((c) => !!c.watch);
     const result = { config, watchConfig };
+
     return result;
   }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -34,7 +34,7 @@ const applyEntry = (entry) => {
   return entry;
 };
 
-const applyPlugin = (config, plugin, attach = false) => {
+const applyPlugin = (config, flags, plugin, attach = false) => {
   const isEmpty = Object.keys(config).length === 0;
 
   if (!config.plugins) {
@@ -45,6 +45,12 @@ const applyPlugin = (config, plugin, attach = false) => {
 
   if (isEmpty) {
     config.entry = ['./src'];
+  }
+
+  // apply watch only if hmr or liveReload is on, if it's the first config, and if --no-watch is not
+  // specified
+  if (!attach && flags.watch !== false) {
+    config.watch = true;
   }
 
   config.entry = applyEntry(config.entry);
@@ -60,13 +66,13 @@ const apply = async (config, flags, configPath) => {
 
   if (flags.all) {
     if (Array.isArray(config)) {
-      config = config.map((c, index) => applyPlugin(c, plugin, index > 0));
+      config = config.map((c, index) => applyPlugin(c, flags, plugin, index > 0));
     } else {
-      config = applyPlugin(config, plugin);
+      config = applyPlugin(config, flags, plugin);
     }
   } else {
     [config] = [].concat(config);
-    config = applyPlugin(config, plugin);
+    config = applyPlugin(config, flags, plugin);
   }
 
   return config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,164 +1102,6 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/anymatch": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
-      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
-    },
-    "@types/body-parser": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/cookies": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.1.tgz",
-      "integrity": "sha512-ku6IvbucEyuC6i4zAVK/KnuzWNXdbFd1HkXlNLg/zhWDGTtQT5VhumiPruB/BHW34PWVFwyfwGftDQHfWNxu3Q==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-      "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.1.tgz",
-      "integrity": "sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "@types/http-assert": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.4.0.tgz",
-      "integrity": "sha512-TZDqvFW4nQwL9DVSNJIJu4lPLttKgzRF58COa7Vs42Ki/MrhIqUbeIw0MWn4kGLiZLXB7oCBibm7nkSjPkzfKQ=="
-    },
-    "@types/http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-l+s0IoxSHqhLFJPDHRfO235kgrCkvFD8JmdV/T9C4BKBYPIjrQopGFH4r7h2e3jQqgJRCthRCAZIxDoFnj1zwQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/http-proxy-middleware": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz",
-      "integrity": "sha512-aXcAs2VEaiHwlFlEqMJ+sNSFCO+wuWXcvdBk5Un7f0tUv1eTIIAmkd4S5D/Yi5JI0xofPpm9h3017TngbrLh7A==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/http-proxy": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/keygrip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
-      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg="
-    },
-    "@types/koa": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.48.tgz",
-      "integrity": "sha512-CiIUYhHlOFJhSCTmsFoFkV2t9ij1JwW26nt0W9XZoWTvmAw6zTE0+k3IAoGICtjzIfhZpZcO323NHmI1LGmdDw==",
-      "requires": {
-        "@types/accepts": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.3.tgz",
-      "integrity": "sha512-kXvR0DPyZ3gaFxZs4WycA8lpzlPGtFmwdbgce+NWd+TG3PycPO3o5FkePH60HoBPd8BBaSiw3vhtgM42O2kQcg==",
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
-    },
-    "@types/node": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
-    },
-    "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
-    },
-    "@types/serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
-      "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
-      }
-    },
-    "@types/tapable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
-      "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ=="
-    },
-    "@types/uglify-js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
-      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
-      "requires": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "@types/webpack": {
-      "version": "4.4.25",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.25.tgz",
-      "integrity": "sha512-YaYVbSK1bC3xiAWFLSgDQyVHdCTNq5cLlcx633basmrwSoUxJiv4SZ0SoT1uoF15zWx98afOcCbqA1YHeCdRYA==",
-      "requires": {
-        "@types/anymatch": "*",
-        "@types/node": "*",
-        "@types/tapable": "*",
-        "@types/uglify-js": "*",
-        "source-map": "^0.6.0"
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -5779,9 +5621,9 @@
       }
     },
     "hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "home-or-tmp": {
       "version": "3.0.0",
@@ -8705,9 +8547,9 @@
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
     "opn": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "requires": {
         "is-wsl": "^1.1.0"
       }
@@ -10045,7 +9887,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -11071,14 +10914,50 @@
         "webpack-sources": "^1.3.0"
       }
     },
-    "webpack-plugin-serve": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/webpack-plugin-serve/-/webpack-plugin-serve-0.7.3.tgz",
-      "integrity": "sha512-04DhzxmlKx4EBSEYIiYJbMVUNwdPfLnQtVt3YElACINtOZv+7K6PegxDv5ZB/rWiKRQUAbqkfsdPIE0xuSw10w==",
+    "webpack-nano": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/webpack-nano/-/webpack-nano-0.6.1.tgz",
+      "integrity": "sha512-bDAtcicPwxJuFXZrGnwL9NTqSrkaHyzuT4uiTM07O9iIHaVVBHiYG5yatIT9jfW8ZgeNbQn500SXTmh92Xs5mA==",
+      "dev": true,
       "requires": {
-        "@types/http-proxy-middleware": "^0.19.2",
-        "@types/koa": "^2.0.48",
-        "@types/webpack": "^4.4.24",
+        "chalk": "^2.4.1",
+        "import-local": "^2.0.0",
+        "rechoir": "^0.6.2",
+        "yargs-parser": "^11.0.0"
+      },
+      "dependencies": {
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "webpack-plugin-serve": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-plugin-serve/-/webpack-plugin-serve-0.8.0.tgz",
+      "integrity": "sha512-aQxQWqdnl+3v6Uf8krRB+cJ9faOPDWfrbHFmf5/oVFiqFeulL5q38V6SWdLlqlA7Biq6VKvXd7odAjd7XPIgDQ==",
+      "requires": {
         "chalk": "^2.4.1",
         "connect-history-api-fallback": "^1.5.0",
         "http-proxy-middleware": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pkg-conf": "^3.0.0",
     "rechoir": "^0.7.0",
     "v8-compile-cache": "^2.0.2",
-    "webpack-plugin-serve": "^0.7.3",
+    "webpack-plugin-serve": "^0.8.0",
     "yargs-parser": "^13.0.0"
   },
   "devDependencies": {
@@ -61,7 +61,8 @@
     "puppeteer": "^1.13.0",
     "standard-version": "^5.0.1",
     "strip-ansi": "^5.1.0",
-    "webpack": "^4.29.6"
+    "webpack": "^4.29.6",
+    "webpack-nano": "^0.6.1"
   },
   "keywords": [
     "development",

--- a/test/fixtures/multi/webpack.config.js
+++ b/test/fixtures/multi/webpack.config.js
@@ -9,8 +9,7 @@ module.exports = [
       filename: './dist-app.js',
       path: resolve(__dirname, './output'),
       publicPath: 'output/'
-    },
-    watch: true
+    }
   },
   {
     context: __dirname,

--- a/test/fixtures/simple/webpack.config.js
+++ b/test/fixtures/simple/webpack.config.js
@@ -8,6 +8,5 @@ module.exports = {
     filename: './output.js',
     path: resolve(__dirname, './output'),
     publicPath: 'output/'
-  },
-  watch: true
+  }
 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

There is potential for breakage in edge cases if users were counting on `webpack-serve` failing to add the `watch: true` property to configs. 

### Please Describe Your Changes

Fixes #5. Adds `watch: true` to the first config in a webpack configuration file. The `--no-watch` flag has been added to prevent that behavior for users who wish to manually setup watching, or for users which need to make use of `watchOptions`.

@pearofducks please review